### PR TITLE
Clear the stdin buffer before question

### DIFF
--- a/fedora-upgrade
+++ b/fedora-upgrade
@@ -1,4 +1,5 @@
 #!/bin/bash
+# vim: sw=3:ts=3:et
 set -e
 
 FEDORA_VERSION=$(rpm -q --qf '%{version}' fedora-release)
@@ -9,10 +10,13 @@ function check_intallation() {
 }
 
 function pause() {
+   # clear the stdin buffer and pause with question
+   read -t 1 -n 10000 discard
    read -p "Hit Enter to continue or Ctrl + C to cancel."
 }
 
 function continue_or_skip() {
+   read -t 1 -n 10000 discard
    echo -e $1
    echo "This step is highly recomended, but can be safely skipped."
    ANSWER='XXX'


### PR DESCRIPTION
For some reason, upgrade was cancelled for me twice today. In both cases thanks
to extra characters in stdin buffer when yum (then rpmconf) were cancelled.

This patch reads 10000 characters in one second to clear the stdin buffer prior
to asking. This is standard practice which prevents this kinds of errors.
