### PR TITLE
Fix the offline update path for fedora 30

### DIFF
--- a/fedora-upgrade
+++ b/fedora-upgrade
@@ -275,7 +275,7 @@ if [ 0$TARGET_VERSION -eq 30 ]; then
     umount_cache_dnf
   elif [ "$ANSWER" == "offline" ] ; then
     install_if_missing dnf-plugin-system-upgrade
-    dnf system-upgrade download ---setopt=module_platform_id=platform:f$TARGET_VERSION -releasever=$TARGET_VERSION
+    dnf system-upgrade download --setopt=module_platform_id=platform:f$TARGET_VERSION --releasever=$TARGET_VERSION
     going_to_reboot
     dnf system-upgrade reboot
   fi


### PR DESCRIPTION
The optional parameters in the update path to fedora 30 have the wrong amount of dashes each. This fixes it.