### PR TITLE
Update remove-retired-packages

### DIFF
--- a/remove-retired-packages
+++ b/remove-retired-packages
@@ -2,6 +2,11 @@
 set -e
 
 source /etc/os-release
+if [[ ! "$1" =~ ^[0-9]*$ ]]
+then
+    echo "usage: $(basename "$0") [fedora version number as digits]."
+    exit 1
+fi
 UPGRADE_FROM="$1"
 if [ -z "$UPGRADE_FROM" ]; then
         UPGRADE_FROM=$(("$VERSION_ID"-1))


### PR DESCRIPTION
DESCRIPTION

remove-retired-packages is a nice program but it does not have any code to check the arguments that it was called with.  By checking to see if remove-retired-packages was called without valid arguments, a useful message can be printed instead of an incidental error message.

STEPS TO REPRODUCE

run:  remove-retired-packages --help

or run: remove-retired-packages thirty-five

etc.

EXPECTED BEHAVIOR

I expect remove-retired-packages would display a useful message.

ACTUAL BEHAVIOR

remove-retired-packages displays an error message that is not helpful.