### PR TITLE
remove dependency on dnf3

### DIFF
--- a/fedora-upgrade.spec
+++ b/fedora-upgrade.spec
@@ -44,7 +44,6 @@ https://fedoraproject.org/wiki/Upgrading
 %package -n remove-retired-packages
 Summary: Remove retired distribution's packages
 Requires: curl
-Requires: python3-dnf
 
 %description -n remove-retired-packages
 Script that removes packages removed from


### PR DESCRIPTION
`remove-retired-packages` uses `dnf` (without qualifying the version), and dnf5 has all the necessary features.

So, remove `dnf3` from the subpackage's requires. `dnf` is in the overall requires already. This allows to have a pure dnf5 system.